### PR TITLE
Tag frames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,10 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# vim
+*.swp
+
+# tf files
+*.gv
+*.pdf

--- a/mobility_sensing/launch/tag_frames.launch
+++ b/mobility_sensing/launch/tag_frames.launch
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<launch>
+  <!-- image_proc removes camera distortion from the raw image stream.
+  its unncessary if we are using fisheye undistorted -->
+  <!-- <node pkg="image_proc" type="image_proc" name="image_projector" ns="fisheye_undistorted"/> -->
+
+  <node pkg="apriltags_ros" type="apriltag_detector_node" name="apriltag_detector" output="screen" ns="fisheye_undistorted">
+    <!-- Remap topic required by the node to custom topics -->
+    <remap from="image_rect" to="image_raw" />
+    <remap from="camera_info" to="camera_info" />
+
+    <!-- Optional: Subscribe to the compressed stream-->
+    <param name="image_transport" type="str" value="raw" />
+
+    <!-- Select the tag family: 16h5, 25h7, 25h9, 36h9, or 36h11(default) -->
+    <param name="tag_family" type="str" value="36h11" />
+
+    <!-- Enable projected optical measurements for more accurate tag transformations -->
+    <!-- This exists for backwards compatability and should be left true for new setups -->
+    <param name="projected_optics" type="bool" value="true" />
+
+    <!-- Describe the tags -->
+    <rosparam param="tag_descriptions">[
+      {id: 0, size: 0.165},
+      {id: 1, size: 0.165},
+      {id: 2, size: 0.165},
+      {id: 3, size: 0.165},
+      {id: 4, size: 0.165},
+      {id: 13, size: 0.053}]
+    </rosparam>
+  </node>
+
+  <node pkg="mobility_sensing" type="tag_frames.py" name="tag_frames" output="screen"></node>
+</launch>

--- a/mobility_sensing/scripts/tag_frames.py
+++ b/mobility_sensing/scripts/tag_frames.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+
+import rospy
+import tf
+
+
+class TagFrames:
+
+    def __init__(self):
+        rospy.init_node('tag_frames')
+        self.listener = tf.TransformListener()
+        self.broadcaster = tf.TransformBroadcaster()
+        self.tags_seen = []
+
+    def tag_detected(self):
+        frame_strings = self.listener.getFrameStrings()
+
+        for frame in frame_strings:
+            # a tag of some id was found
+            if 'tag_' in frame:
+
+                # TODO: only works with one tag
+                return frame
+
+    def publish_tag_odom_transform(self, tag_frame):
+
+        if (self.listener.frameExists("odom")
+                and self.listener.frameExists(tag_frame)):
+
+            try:
+                # One way
+                t = self.listener.getLatestCommonTime("odom", tag_frame)
+                trans, rot = self.listener.lookupTransform("odom",
+                                                           tag_frame,
+                                                           t)
+
+                print trans, rot
+                self.broadcaster.sendTransform(trans,
+                                               rot,
+                                               rospy.get_rostime(),
+                                               "odom",
+                                               "AR")
+            except (tf.ExtrapolationException,
+                    tf.LookupException,
+                    tf.ConnectivityException) as e:
+                print e
+                return
+
+    def run(self):
+        """ The main run loop """
+        r = rospy.Rate(10)
+
+        while not rospy.is_shutdown():
+            tag_detected = self.tag_detected()
+            if tag_detected:
+
+                # if this is the first tag we saw or have seen
+                if (len(self.tags_seen) == 0
+                        or self.tags_seen[0] == tag_detected):
+                    self.publish_tag_odom_transform(tag_detected)
+
+            r.sleep()
+
+
+if __name__ == "__main__":
+    node = TagFrames()
+    node.run()

--- a/mobility_sensing/scripts/tag_frames.py
+++ b/mobility_sensing/scripts/tag_frames.py
@@ -28,8 +28,11 @@ class TagFrames:
 
             try:
                 t = self.listener.getLatestCommonTime("odom", tag_frame)
+                # self.AR_trans, self.AR_rot = self.listener.lookupTransform(
+                #         "odom", tag_frame, t)
                 self.AR_trans, self.AR_rot = self.listener.lookupTransform(
-                        "odom", tag_frame, t)
+                        tag_frame, "odom", t)
+                print self.AR_trans, self.AR_rot
                 print self.AR_trans, self.AR_rot
 
             except (tf.ExtrapolationException,


### PR DESCRIPTION
This connects the TF frame of various apriltags into the TF tree.
![ar-ar_x-tftree](https://user-images.githubusercontent.com/5459644/27342833-4405c2ba-55af-11e7-96ab-57ac5b89bfa8.png)

To test:
`roslaunch mobility_sensing tag_frames.launch`
Run rviz, and "Add" "By Display Type" TF.

For future:  Attach a simple "game" or audio feedback loop to this.
For example, a soundscape which mixes together all these audio sounds, based on distance away from each AR_x tag frame.  